### PR TITLE
Fixed typos in server start and type error in message

### DIFF
--- a/Hugofy.py
+++ b/Hugofy.py
@@ -44,8 +44,9 @@ class HugoserverCommand(sublime_plugin.TextCommand):
 		server=settings.get("Server")
 		theme=settings.get("DefaultTheme")
 		try:
-			out=subprocess.Popen("hugo server --theme="+theme+"--buildDrafts --watch --port="+server["PORT"],stderr=subprocess.STDOUT,universal_newlines=True)
-			sublime.status_message(out)
+			startCmd = "hugo server --theme={} --buildDrafts --watch --port={}".format(theme, server["PORT"])
+			out=subprocess.Popen(startCmd,stderr=subprocess.STDOUT,universal_newlines=True)
+			sublime.status_message('Server Started: {}'.format(startCmd))
 		except:
 			sublime.error_message("Error starting server")
 


### PR DESCRIPTION
- Added space between the theme name and the `--buildDrafts`option
- Changed string concatenation to format string (otherwise `server["PORT"]` will fail if it is an int and not explicitly cast to a string)
- `sublime.status_message(out)`was failing as out is a Popen process, not a string, changed it to a relevant status message
