### PR TITLE
Make run command more configurable

### DIFF
--- a/Hugofy.py
+++ b/Hugofy.py
@@ -42,9 +42,15 @@ class HugoserverCommand(sublime_plugin.TextCommand):
 	def run(self,edit):
 		setvars()
 		server=settings.get("Server")
-		theme=settings.get("DefaultTheme")
+		startCmd = ["hugo", "server"]
+		if server["THEME_FLAG"]:
+			startCmd = startCmd + ["--theme={}".format(server["THEME"])]
+		if server["DRAFTS_FLAG"]:
+			startCmd = startCmd + ["--buildDrafts"]
+
+		startCmd = startCmd + ["--watch", "--port={}".format(server["PORT"])] 
+
 		try:
-			startCmd = ["hugo", "server", "--theme={}".format(theme), "--buildDrafts", "--watch", "--port={}".format(server["PORT"])]
 			out=subprocess.Popen(startCmd,stderr=subprocess.STDOUT,universal_newlines=True)
 			sublime.status_message('Server Started: {}'.format(startCmd))
 		except:

--- a/hugofy.sublime-settings
+++ b/hugofy.sublime-settings
@@ -1,13 +1,14 @@
 {
-	//name of theme to run hugo with
-	"DefaultTheme": "bootstrap",
-	//root directory for hugo website use double backwork slash for windows
+	//root directory for hugo websites use double backwork slash for windows
 	//e.g. windows C:\\Users\\myusername\\
 	//e.g. Linux/Mac /home/myusername
 	"Directory": "C:\\Users\\amitm\\OneDrive\\Documents\\Projects\\hugo\\mySite",
 	"Server":
 	{
 		"PORT": 8000 //server port number
+		"THEME_FLAG": true //use `--theme` flag
+		"DRAFTS_FLAG": true //use `--buildDrafts` flag
+		"THEME": "bootstrap" //theme used by `--theme` flag
 	},
 	//website name
 	"Sitename": "MyFirstsite"  


### PR DESCRIPTION
I don't use a theme, and I suspect others set the theme in their config.toml, so the run command fails.

This PR pushes more of the command config into the settings, with the defaults set to run as the plugin had previously.

