### PR TITLE
make hugo directory more generic

### DIFF
--- a/Hugofy.py
+++ b/Hugofy.py
@@ -1,94 +1,125 @@
-import sublime, sublime_plugin,subprocess,os
+import sublime, sublime_plugin, subprocess, os
+
 
 def setvars():
-	global settings,path,sitename
-	settings=sublime.load_settings("hugofy.sublime-settings")
-	path=settings.get("Directory")
-	sitename=settings.get("Sitename")
-	if not os.path.exists(os.path.join(path,sitename)):
-		 os.makedirs(os.path.join(path,sitename))
-	os.chdir(os.path.join(path,sitename))
+    global settings, path, sitename
+    settings = sublime.load_settings("hugofy.sublime-settings")
+    path = settings.get("Directory")
+    sitename = settings.get("Sitename")
+    if not os.path.exists(os.path.join(path, sitename)):
+        os.makedirs(os.path.join(path, sitename))
+    os.chdir(os.path.join(path, sitename))
+
 
 class HugonewsiteCommand(sublime_plugin.TextCommand):
-	def run(self, edit):
-		setvars()
-		process=["hugo", "new", "site", os.path.join(path,sitename)]
-		subprocess.Popen(process)
+    def run(self, edit):
+        setvars()
+        process = ["hugo", "new", "site", os.path.join(path, sitename)]
+        subprocess.Popen(process)
+
 
 class HugonewcontentCommand(sublime_plugin.TextCommand):
-	def on_done(self,pagename):
-		if not pagename:
-			sublime.error_message("No filename provided")
-		process=["hugo", "new", pagename]
-		subprocess.Popen(process)
-		sublime.active_window().open_file(os.path.join(path,sitename,"content",pagename))
-	def on_change(self,filename):
-		pass
-	def on_cancel(self):
-		sublime.error_message("No filename provided")
-	def run(self,edit):
-		setvars()
-		sublime.active_window().show_input_panel("Enter file name", "", self.on_done, self.on_change, self.on_cancel)
+    def on_done(self, pagename):
+        if not pagename:
+            sublime.error_message("No filename provided")
+        process = ["hugo", "new", pagename]
+        subprocess.Popen(process)
+        sublime.active_window().open_file(
+            os.path.join(path, sitename, "content", pagename)
+        )
+
+    def on_change(self, filename):
+        pass
+
+    def on_cancel(self):
+        sublime.error_message("No filename provided")
+
+    def run(self, edit):
+        setvars()
+        sublime.active_window().show_input_panel(
+            "Enter file name", "", self.on_done, self.on_change, self.on_cancel
+        )
+
 
 class HugoversionCommand(sublime_plugin.TextCommand):
-	def run(self,edit):
-		try:
-			out=subprocess.check_output(["hugo", "version"],stderr=subprocess.STDOUT,universal_newlines=True)
-			sublime.message_dialog(out)
-		except:
-			sublime.error_message("Hugo not installed or path not set")
+    def run(self, edit):
+        try:
+            out = subprocess.check_output(
+                ["hugo", "version"], stderr=subprocess.STDOUT, universal_newlines=True
+            )
+            sublime.message_dialog(out)
+        except:
+            sublime.error_message("Hugo not installed or path not set")
+
 
 class HugoserverCommand(sublime_plugin.TextCommand):
-	def run(self,edit):
-		setvars()
-		server=settings.get("Server")
-		startCmd = ["hugo", "server"]
-		if server["THEME_FLAG"]:
-			startCmd = startCmd + ["--theme={}".format(server["THEME"])]
-		if server["DRAFTS_FLAG"]:
-			startCmd = startCmd + ["--buildDrafts"]
+    def run(self, edit):
+        setvars()
+        server = settings.get("Server")
+        startCmd = ["hugo", "server"]
+        if server["THEME_FLAG"]:
+            startCmd = startCmd + ["--theme={}".format(server["THEME"])]
+        if server["DRAFTS_FLAG"]:
+            startCmd = startCmd + ["--buildDrafts"]
 
-		startCmd = startCmd + ["--watch", "--port={}".format(server["PORT"])] 
+        startCmd = startCmd + ["--watch", "--port={}".format(server["PORT"])]
 
-		try:
-			out=subprocess.Popen(startCmd,stderr=subprocess.STDOUT,universal_newlines=True)
-			sublime.status_message('Server Started: {}'.format(startCmd))
-		except:
-			sublime.error_message("Error starting server")
+        try:
+            out = subprocess.Popen(
+                startCmd, stderr=subprocess.STDOUT, universal_newlines=True
+            )
+            sublime.status_message("Server Started: {}".format(startCmd))
+        except:
+            sublime.error_message("Error starting server")
 
 
 class HugobuildCommand(sublime_plugin.TextCommand):
-	def run(self,edit):
-		try:
-			out=subprocess.Popen(["hugo", "--buildDrafts"],stdout=subprocess.PIPE)
-			#print(out.communicate()[0].decode('utf-8'))
-			sublime.message_dialog(out.communicate()[0].decode('utf-8'))
-		except:
-			sublime.error_message("Hugo not installed")
+    def run(self, edit):
+        try:
+            out = subprocess.Popen(["hugo", "--buildDrafts"], stdout=subprocess.PIPE)
+            # print(out.communicate()[0].decode('utf-8'))
+            sublime.message_dialog(out.communicate()[0].decode("utf-8"))
+        except:
+            sublime.error_message("Hugo not installed")
+
 
 class HugogetthemesCommand(sublime_plugin.TextCommand):
-	"""download themes for hugo"""
-	def run(self,edit):
-		setvars()
-		try:
-			out=subprocess.Popen(["git", "clone", "--recursive", "https://github.com/spf13/hugoThemes.git", os.path.join(path,sitename,"themes")], stderr=subprocess.STDOUT,universal_newlines=True)
-		except:
-			sublime.error_message("git not installed or path not set")
+    """download themes for hugo"""
+
+    def run(self, edit):
+        setvars()
+        try:
+            out = subprocess.Popen(
+                [
+                    "git",
+                    "clone",
+                    "--recursive",
+                    "https://github.com/spf13/hugoThemes.git",
+                    os.path.join(path, sitename, "themes"),
+                ],
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+            )
+        except:
+            sublime.error_message("git not installed or path not set")
+
 
 class HugosetthemeCommand(sublime_plugin.TextCommand):
-	def on_done(self,themename):
-		if not themename:
-			sublime.error_message("No theme name provided")
-		else:
-			settings.set("DefaultTheme",themename)
-			sublime.save_settings("hugofy.sublime-settings")
+    def on_done(self, themename):
+        if not themename:
+            sublime.error_message("No theme name provided")
+        else:
+            settings.set("DefaultTheme", themename)
+            sublime.save_settings("hugofy.sublime-settings")
 
-	def on_change(self,themename):
-		pass
-	def on_cancel(self):
-		pass
+    def on_change(self, themename):
+        pass
 
-	def run(self,edit):
-		setvars()
-		sublime.active_window().show_input_panel("Enter theme name", "", self.on_done, self.on_change, self.on_cancel)
+    def on_cancel(self):
+        pass
 
+    def run(self, edit):
+        setvars()
+        sublime.active_window().show_input_panel(
+            "Enter theme name", "", self.on_done, self.on_change, self.on_cancel
+        )

--- a/Hugofy.py
+++ b/Hugofy.py
@@ -1,21 +1,21 @@
 import sublime, sublime_plugin, subprocess, os
+from contextlib import contextmanager
+
+
+@contextmanager
+def cwd(path):
+    oldpwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(oldpwd)
 
 
 def setvars():
     global settings, path, sitename
     settings = sublime.load_settings("hugofy.sublime-settings")
-    path = settings.get("Directory")
-    sitename = settings.get("Sitename")
-    if not os.path.exists(os.path.join(path, sitename)):
-        os.makedirs(os.path.join(path, sitename))
-    os.chdir(os.path.join(path, sitename))
-
-
-class HugonewsiteCommand(sublime_plugin.TextCommand):
-    def run(self, edit):
-        setvars()
-        process = ["hugo", "new", "site", os.path.join(path, sitename)]
-        subprocess.Popen(process)
+    path = sublime.active_window().folders()[0]
 
 
 class HugonewcontentCommand(sublime_plugin.TextCommand):
@@ -23,10 +23,9 @@ class HugonewcontentCommand(sublime_plugin.TextCommand):
         if not pagename:
             sublime.error_message("No filename provided")
         process = ["hugo", "new", pagename]
-        subprocess.Popen(process)
-        sublime.active_window().open_file(
-            os.path.join(path, sitename, "content", pagename)
-        )
+        with cwd(path):
+            subprocess.Popen(process)
+        sublime.active_window().open_file(os.path.join(path, "content", pagename))
 
     def on_change(self, filename):
         pass
@@ -55,36 +54,41 @@ class HugoversionCommand(sublime_plugin.TextCommand):
 class HugoserverCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         setvars()
-        server = settings.get("Server")
-        startCmd = ["hugo", "server"]
-        if server["THEME_FLAG"]:
-            startCmd = startCmd + ["--theme={}".format(server["THEME"])]
-        if server["DRAFTS_FLAG"]:
-            startCmd = startCmd + ["--buildDrafts"]
+        # server = settings.get("Server")
 
-        startCmd = startCmd + ["--watch", "--port={}".format(server["PORT"])]
+        start_cmd = ["hugo", "server"]
+        port = settings.get("PORT")
+
+        if settings.get("DRAFTS_FLAG"):
+            start_cmd = start_cmd + ["--buildDrafts"]
+
+        start_cmd = start_cmd + ["--watch", "--port=%s" % port]
 
         try:
-            out = subprocess.Popen(
-                startCmd, stderr=subprocess.STDOUT, universal_newlines=True
-            )
-            sublime.status_message("Server Started: {}".format(startCmd))
-        except:
-            sublime.error_message("Error starting server")
+            with cwd(path):
+                out = subprocess.Popen(
+                    start_cmd, stderr=subprocess.STDOUT, universal_newlines=True
+                )
+            sublime.status_message("Server started: {}".format(start_cmd))
+        except Exception as e:
+            sublime.error_message("Error starting server: {}".format(e))
 
 
 class HugobuildCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         try:
-            out = subprocess.Popen(["hugo", "--buildDrafts"], stdout=subprocess.PIPE)
+            with cwd(path):
+                out = subprocess.Popen(
+                    ["hugo", "--buildDrafts"], stdout=subprocess.PIPE
+                )
             # print(out.communicate()[0].decode('utf-8'))
             sublime.message_dialog(out.communicate()[0].decode("utf-8"))
-        except:
-            sublime.error_message("Hugo not installed")
+        except Exception as e:
+            sublime.error_message("Exception caught {}".format(e))
 
 
 class HugogetthemesCommand(sublime_plugin.TextCommand):
-    """download themes for hugo"""
+    """Download all themes for Hugo."""
 
     def run(self, edit):
         setvars()
@@ -95,31 +99,10 @@ class HugogetthemesCommand(sublime_plugin.TextCommand):
                     "clone",
                     "--recursive",
                     "https://github.com/spf13/hugoThemes.git",
-                    os.path.join(path, sitename, "themes"),
+                    os.path.join(path, "themes"),
                 ],
                 stderr=subprocess.STDOUT,
                 universal_newlines=True,
             )
         except:
             sublime.error_message("git not installed or path not set")
-
-
-class HugosetthemeCommand(sublime_plugin.TextCommand):
-    def on_done(self, themename):
-        if not themename:
-            sublime.error_message("No theme name provided")
-        else:
-            settings.set("DefaultTheme", themename)
-            sublime.save_settings("hugofy.sublime-settings")
-
-    def on_change(self, themename):
-        pass
-
-    def on_cancel(self):
-        pass
-
-    def run(self, edit):
-        setvars()
-        sublime.active_window().show_input_panel(
-            "Enter theme name", "", self.on_done, self.on_change, self.on_cancel
-        )

--- a/Hugofy.sublime-commands
+++ b/Hugofy.sublime-commands
@@ -1,10 +1,8 @@
 [
-   
-    { "caption": "Hugofy : New Site", "command": "hugonewsite" },
+
     { "caption": "Hugofy : New Post", "command": "hugonewcontent"},
     { "caption": "Hugofy : Version", "command": "hugoversion"},
     { "caption": "Hugofy : Build", "command": "hugobuild"},
     { "caption": "Hugofy : Start Server", "command": "hugoserver"},
-    { "caption": "Hugofy : Set Theme", "command": "hugosettheme"},
     { "caption": "Hugofy : Download themes", "command": "hugogetthemes"},
 ]

--- a/Hugofy.sublime-commands
+++ b/Hugofy.sublime-commands
@@ -1,8 +1,9 @@
 [
-
+    { "caption": "Hugofy : New Site", "command": "hugonewsite" },
     { "caption": "Hugofy : New Post", "command": "hugonewcontent"},
     { "caption": "Hugofy : Version", "command": "hugoversion"},
     { "caption": "Hugofy : Build", "command": "hugobuild"},
     { "caption": "Hugofy : Start Server", "command": "hugoserver"},
+    { "caption": "Hugofy : Set Theme", "command": "hugosettheme"},
     { "caption": "Hugofy : Download themes", "command": "hugogetthemes"},
 ]

--- a/hugofy.sublime-settings
+++ b/hugofy.sublime-settings
@@ -1,15 +1,4 @@
 {
-	//root directory for hugo websites use double backwork slash for windows
-	//e.g. windows C:\\Users\\myusername\\
-	//e.g. Linux/Mac /home/myusername
-	"Directory": "C:\\Users\\amitm\\OneDrive\\Documents\\Projects\\hugo\\mySite",
-	"Server":
-	{
-		"PORT": 8000, //server port number
-		"THEME_FLAG": true, //use `--theme` flag
-		"DRAFTS_FLAG": true, //use `--buildDrafts` flag
-		"THEME": "bootstrap" //theme used by `--theme` flag
-	},
-	//website name
-	"Sitename": "MyFirstsite"  
+	"PORT": 8000, //server port number
+	"DRAFTS_FLAG": true, //use `--buildDrafts` flag
 }

--- a/hugofy.sublime-settings
+++ b/hugofy.sublime-settings
@@ -1,4 +1,15 @@
 {
-	"PORT": 8000, //server port number
-	"DRAFTS_FLAG": true, //use `--buildDrafts` flag
+    // server port number
+	"PORT": 8000,
+    // use `--buildDrafts` flag
+	"DRAFTS_FLAG": true,
+
+    // OPTIONAL FIELDS:
+
+    // if THEME_NAME is present, then we will build using that theme,
+    // "THEME_NAME": "",
+
+    // if DIR_PATH is present, then we start Hugo there
+    // default to the open directory in your sublime window
+    // "DIR_PATH": "",
 }


### PR DESCRIPTION
relatively large change, the goal is to launch hugo properly for any arbitrary folder which represents a hugo deployment.

other changes:
- ran [black](https://github.com/ambv/black) for code quality purposes
- use a context manager to manage working directory
- generalize the new site command to take a different directory
- generalize the `theme_name` setting
- remove sitename parameter since it's only used by one command and we add an input manager for it anyways